### PR TITLE
Added DEFAULT NOW() to created_at field definition

### DIFF
--- a/src/main/resources/db/migration/V002__Notifications_default_created_at.sql
+++ b/src/main/resources/db/migration/V002__Notifications_default_created_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notifications ALTER COLUMN created_at SET DEFAULT NOW();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1088


### Change description ###
Added DEFAULT NOW() to the definition of created_at field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
