### PR TITLE
Add mark as sent method for updating notifications after pushing to API

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -72,7 +72,7 @@ public class NotificationRepositoryTest {
         jdbcTemplate.update(
             "UPDATE notifications SET status = :sent WHERE id = :id",
             new MapSqlParameterSource()
-                .addValue("sent", SENT)
+                .addValue("sent", SENT.name())
                 .addValue("id", idSent)
         );
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.PENDING;
+import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.SENT;
 
 @SpringBootTest
 public class NotificationRepositoryTest {
@@ -64,6 +65,13 @@ public class NotificationRepositoryTest {
         jdbcTemplate.update(
             "UPDATE notifications SET notification_id = 'SOME_ID' WHERE id = :id",
             new MapSqlParameterSource("id", idSentStillPending)
+        );
+        long idSent = notificationRepository.insert(createNewNotification());
+        jdbcTemplate.update(
+            "UPDATE notifications SET status = :sent WHERE id = :id",
+            new MapSqlParameterSource()
+                .addValue("sent", SENT)
+                .addValue("id", idSent)
         );
 
         // when

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.PENDING;
+import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.SENT;
 
 @Repository
 public class NotificationRepository {
@@ -71,5 +72,27 @@ public class NotificationRepository {
         );
 
         return (long) keyHolder.getKey();
+    }
+
+    /**
+     * Mark notification as sent.
+     * @param id notification ID
+     * @param notificationId ID of notification provided by API
+     * @return update was successful
+     */
+    public boolean markAsSent(long id, String notificationId) {
+        int rowsUpdated = jdbcTemplate.update(
+            "UPDATE notifications "
+                + "SET notification_id = :notificationId, "
+                + "  processed_at = NOW(), "
+                + "  status = :status "
+                + "WHERE id = :id",
+            new MapSqlParameterSource()
+                .addValue("notificationId", notificationId)
+                .addValue("status", SENT.name())
+                .addValue("id", id)
+        );
+
+        return rowsUpdated == 1;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationStatus.java
@@ -3,4 +3,5 @@ package uk.gov.hmcts.reform.notificationservice.data;
 enum NotificationStatus {
 
     PENDING,
+    SENT,
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Process message from DB](https://tools.hmcts.net/jira/browse/BPS-1092)

### Change description ###

After retrieving all notifications (#30 + #31) and sending all to API (TBD), we need to mark them as SENT. Doing separate DB interaction in this - separate PR so it can be orchestrated easily in the future

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
