### PR TITLE
Add trace-id and span-id to logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,7 @@ dependencies {
   implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.2.RELEASE'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-sleuth', version: '2.2.2.RELEASE'
 
   implementation group: 'com.microsoft.azure', name: 'azure-servicebus', version: '3.1.5'
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ spring:
       poolName: NotificationHikariCP
       maxLifetime: 7200000
       connectionTimeout: 30000
+  sleuth:
+    traceId128: true
 
 flyway:
   skip-migrations: ${FLYWAY_SKIP_MIGRATIONS}
@@ -35,3 +37,6 @@ queue:
   notifications:
     read-connection-string: ${QUEUE_NOTIFICATIONS_READ}
 
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%X{traceId}/%X{spanId}] %-5p %logger{36} [%t] %C{2} - %m%n"


### PR DESCRIPTION


### Change description ###

use spring sleuth to Add trace-id and span-id to logs so we can trace the requests , messages beginning to end.

when ever app receives  new request if there is trace id and span id in the header it uses these ids and add to logs.
if there is not trace id in the header it creates new trace-id,  when it makes request to other services it (if we have not done sth custom) passes this trace id to other service in http header.
it can create new ids when it receives message via JMS.
we can trigger manually to create.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
