### PR TITLE
Add mark as failed repository method

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.FAILED;
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.PENDING;
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.SENT;
 
@@ -308,6 +309,36 @@ public class NotificationRepositoryTest {
             .satisfies(notification -> {
                 assertThat(notification.notificationId).isEqualTo(NOTIFICATION_ID);
                 assertThat(notification.status).isEqualTo(SENT);
+                assertThat(notification.processedAt).isNotNull();
+            });
+    }
+
+    @Test
+    void should_return_flag_false_when_mark_as_failure_did_not_find_any_notification_to_update() {
+        // when
+        boolean isMarked = notificationRepository.markAsFailure(1_000);
+
+        // then
+        assertThat(isMarked).isFalse();
+    }
+
+    @Test
+    void should_return_flag_true_when_mark_as_failure_was_successful() {
+        // given
+        long id = notificationRepository.insert(createNewNotification());
+
+        // when
+        boolean isMarked = notificationRepository.markAsFailure(id);
+
+        // then
+        assertThat(isMarked).isTrue();
+
+        // and
+        assertThat(notificationRepository.find(id))
+            .isNotEmpty()
+            .get()
+            .satisfies(notification -> {
+                assertThat(notification.status).isEqualTo(FAILED);
                 assertThat(notification.processedAt).isNotNull();
             });
     }

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.FAILED;
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.PENDING;
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.SENT;
 
@@ -100,6 +101,25 @@ public class NotificationRepository {
             new MapSqlParameterSource()
                 .addValue("notificationId", notificationId)
                 .addValue("status", SENT.name())
+                .addValue("id", id)
+        );
+
+        return rowsUpdated == 1;
+    }
+
+    /**
+     * Mark notification as failed.
+     * @param id notification ID
+     * @return update was successful
+     */
+    public boolean markAsFailure(long id) {
+        int rowsUpdated = jdbcTemplate.update(
+            "UPDATE notifications "
+                + "SET processed_at = NOW(), "
+                + "  status = :status "
+                + "WHERE id = :id",
+            new MapSqlParameterSource()
+                .addValue("status", FAILED.name())
                 .addValue("id", id)
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Process message from DB](https://tools.hmcts.net/jira/browse/BPS-1092)

### Change description ###

As being fast pacing I've missed another step from notifying client API which requires action in DB - marking as failed. Could've included as part of #32 but hey - we can say everything is extra separate now :man_shrugging: 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
