### PR TITLE
Add task for pending notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/task/PendingNotificationsTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/task/PendingNotificationsTask.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.notificationservice.task;
+
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.notificationservice.service.NotificationService;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+@Component
+public class PendingNotificationsTask {
+
+    private static final Logger log = getLogger(PendingNotificationsTask.class);
+    private static final String TASK_NAME = "pending-notifications";
+
+    private final NotificationService notificationService;
+
+    public PendingNotificationsTask(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    public void run() {
+        log.info("Started {} task", TASK_NAME);
+
+        notificationService.processPendingNotifications();
+
+        log.info("Finished {} task", TASK_NAME);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/task/PendingNotificationsTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/task/PendingNotificationsTaskTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.notificationservice.task;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.notificationservice.service.NotificationService;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PendingNotificationsTaskTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Test
+    void should_call_service_once() {
+        new PendingNotificationsTask(notificationService).run();
+
+        verify(notificationService, times(1)).processPendingNotifications();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Process message from DB](https://tools.hmcts.net/jira/browse/BPS-1092)

### Change description ###

Task unit add - just a task. Next:

- scheduler config
- shedlock config
- enable task

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
