### PR TITLE
Prepare pipeline for functional tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,10 @@
 #!groovy @Library("Infrastructure") @Library("Infrastructure")
 @Library("Infrastructure")
+
+import uk.gov.hmcts.contino.DockerImage
 import uk.gov.hmcts.contino.GradleBuilder
+import uk.gov.hmcts.contino.Kubectl
+import uk.gov.hmcts.pipeline.TeamConfig
 
 def type = "java"
 def product = "reform-scan"
@@ -13,6 +17,26 @@ GradleBuilder builder = new GradleBuilder(this, product)
 withPipeline(type, product, component) {
   after('test') {
     builder.gradle('integration')
+  }
+
+  before('smoketest:preview') {
+    withAksClient('nonprod') {
+      // Notifications queue connection string is needed by the functional tests.
+      // The following code (as ugly as it looks!) gets it from the k8s cluster
+      def dockerImage = new DockerImage(product, component, null, env.BRANCH_NAME, env.GIT_COMMIT)
+      def subscription = env.SUBSCRIPTION_NAME
+      def aksServiceName = dockerImage.getAksServiceName().toLowerCase()
+      def sbNamespaceSecret = "servicebus-secret-namespace-${aksServiceName}"
+      def namespace = new TeamConfig(this).getNameSpace(product)
+
+      def kubectl = new Kubectl(this, subscription, namespace)
+      kubectl.login()
+
+      // Get notifications queue connection string
+      def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
+      env.NOTIFICATION_QUEUE_CONN_STRING_READ = "${sbConnectionStr};EntityPath=notifications"
+      env.NOTIFICATION_QUEUE_CONN_STRING_WRITE = "${sbConnectionStr};EntityPath=notifications"
+    }
   }
 
   enableDbMigration('reform-scan') // vault 'prefix'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -14,6 +14,22 @@ def channel = '#bsp-build-notices'
 
 GradleBuilder builder = new GradleBuilder(this, product)
 
+def nonPrSecrets = [
+  'bulk-scan-${env}': [
+    secret('notifications-queue-listen-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_READ'),
+    secret('notifications-queue-send-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_WRITE')
+  ]
+]
+
+static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
+  [ $class: 'AzureKeyVaultSecret',
+    secretType: 'Secret',
+    name: secretName,
+    version: '',
+    envVariable: envVar
+  ]
+}
+
 withPipeline(type, product, component) {
   after('test') {
     builder.gradle('integration')
@@ -44,4 +60,8 @@ withPipeline(type, product, component) {
   installCharts()
   enableSlackNotifications(channel)
   disableLegacyDeployment()
+
+  onNonPR() {
+    loadVaultSecrets(nonPrSecrets)
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -243,12 +243,7 @@ dependencies {
   }
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
-  functionalTestImplementation libraries.junit5
-  functionalTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.15.0'
-  functionalTestImplementation group: 'com.typesafe', name: 'config', version: '1.4.0'
-  functionalTestImplementation group: 'io.rest-assured', name: 'rest-assured', {
-    exclude group: 'junit', module: 'junit'
-  }
+  functionalTestImplementation sourceSets.smokeTest.runtimeClasspath
 }
 
 mainClassName = 'uk.gov.hmcts.reform.notificationservice.Application'

--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,10 @@ ext.libraries = [
     "org.junit.platform:junit-platform-engine:${versions.junitPlatform}"
   ]
 ]
-ext["rest-assured.version"] = '4.3.0'
+// 4.3.0 + java v9 and above are not easily compatible
+// addition of rest-assured-all suppose to help but it didn't
+// leaving that dependency doesn't break but gives a reminder on "how it should be fixed"
+ext["rest-assured.version"] = '4.2.0'
 
 dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.11'
@@ -238,9 +241,8 @@ dependencies {
   smokeTestImplementation libraries.junit5
   smokeTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.15.0'
   smokeTestImplementation group: 'com.typesafe', name: 'config', version: '1.4.0'
-  smokeTestImplementation group: 'io.rest-assured', name: 'rest-assured', {
-    exclude group: 'junit', module: 'junit'
-  }
+  smokeTestImplementation group: 'io.rest-assured', name: 'rest-assured-all', version: '4.3.0' // fix for >java9 envs
+  smokeTestImplementation group: 'io.rest-assured', name: 'rest-assured'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.smokeTest.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,7 @@ ext.libraries = [
     "org.junit.platform:junit-platform-engine:${versions.junitPlatform}"
   ]
 ]
+ext["rest-assured.version"] = '4.3.0'
 
 dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.11'

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -1,1 +1,3 @@
 test-url=${TEST_URL}
+test-notification-queue-connection-string-read=${NOTIFICATION_QUEUE_CONN_STRING_READ}
+test-notification-queue-connection-string-write=${NOTIFICATION_QUEUE_CONN_STRING_WRITE}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Process message from DB](https://tools.hmcts.net/jira/browse/BPS-1092)

### Change description ###

Involved changes are:
- env vars for notification queue:
  - PRs
  - master
- bau: missed rest-assured version set. was behind 4.3.0 -> 3.3.0 :see_no_evil: 
- same set up is for smoke tests. reusing the config

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
