### PR TITLE
Bug: secure feign exceptions with `-1` status

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationService.java
@@ -84,10 +84,12 @@ public class NotificationService {
 
             notificationRepository.markAsFailure(notification.id);
         } catch (FeignException exception) {
+            var status = HttpStatus.resolve(exception.status());
+
             log.error(
                 "Received {} from client. Postponing notification for later. "
                     + "Service: {}, Zip file: {}, ID: {}, Client response: {}",
-                HttpStatus.valueOf(exception.status()).getReasonPhrase(),
+                (status == null ? HttpStatus.INTERNAL_SERVER_ERROR : status).getReasonPhrase(),
                 notification.service,
                 notification.zipFileName,
                 notification.id,

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.notificationservice.service;
 
 import feign.FeignException;
 import org.slf4j.Logger;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.notificationservice.clients.ErrorNotificationClient;
@@ -70,11 +69,10 @@ public class NotificationService {
                 response.getNotificationId()
             );
         } catch (FeignException.BadRequest | FeignException.UnprocessableEntity exception) {
-            var status = HttpStatus.valueOf(exception.status());
-
             log.error(
-                "Received {} from client. Marking as failure. Service: {}, Zip file: {}, ID: {}, Client response: {}",
-                status.getReasonPhrase(),
+                "Received http status {} from client. Marking as failure. "
+                    + "Service: {}, Zip file: {}, ID: {}, Client response: {}",
+                exception.status(),
                 notification.service,
                 notification.zipFileName,
                 notification.id,
@@ -84,12 +82,10 @@ public class NotificationService {
 
             notificationRepository.markAsFailure(notification.id);
         } catch (FeignException exception) {
-            var status = HttpStatus.resolve(exception.status());
-
             log.error(
-                "Received {} from client. Postponing notification for later. "
+                "Received http status {} from client. Postponing notification for later. "
                     + "Service: {}, Zip file: {}, ID: {}, Client response: {}",
-                (status == null ? HttpStatus.INTERNAL_SERVER_ERROR : status).getReasonPhrase(),
+                exception.status(),
                 notification.service,
                 notification.zipFileName,
                 notification.id,

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationServiceTest.java
@@ -100,7 +100,7 @@ class NotificationServiceTest {
     ) {
         // given
         var notification = getSampleNotification();
-        var exception = exceptionClass.getCanonicalName().equals(FeignException.class.getCanonicalName())
+        var exception = exceptionClass.equals(FeignException.class)
             ? getDefaultFeignException()
             : instantiateFeignException(exceptionClass);
         given(notificationRepository.findPending()).willReturn(singletonList(notification));

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationServiceTest.java
@@ -90,14 +90,21 @@ class NotificationServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(classes = {FeignException.NotFound.class, FeignException.InternalServerError.class})
+    @ValueSource(classes = {
+        FeignException.class,
+        FeignException.NotFound.class,
+        FeignException.InternalServerError.class
+    })
     void should_leave_notification_record_as_is_when_relevant_exception_from_client_is_caught(
         Class<FeignException> exceptionClass
     ) {
         // given
         var notification = getSampleNotification();
+        var exception = exceptionClass.getCanonicalName().equals(FeignException.class.getCanonicalName())
+            ? getDefaultFeignException()
+            : instantiateFeignException(exceptionClass);
         given(notificationRepository.findPending()).willReturn(singletonList(notification));
-        willThrow(instantiateFeignException(exceptionClass)).given(notificationClient).notify(any());
+        willThrow(exception).given(notificationClient).notify(any());
 
         // when
         notificationService.processPendingNotifications();
@@ -210,24 +217,32 @@ class NotificationServiceTest {
 
     @SuppressWarnings("LineLength")
     private FeignException instantiateFeignException(Class<FeignException> exceptionClass) {
-        byte[] emptyByteArray = new byte[]{};
+        var request = getFeignRequest();
 
         try {
             return exceptionClass
-                .getConstructor(String.class, Request.class, emptyByteArray.getClass())
-                .newInstance(
-                    "message",
-                    Request.create(
-                        Request.HttpMethod.POST,
-                        "/notify",
-                        emptyMap(),
-                        Request.Body.create(emptyByteArray),
-                        null
-                    ),
-                    emptyByteArray
-                );
+                .getConstructor(String.class, Request.class, request.body().getClass())
+                .newInstance("message", request, request.body());
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException("Could not construct FeignException", e);
         }
+    }
+
+    private FeignException getDefaultFeignException() {
+        var request = getFeignRequest();
+
+        return new FeignException.FeignClientException(-1, "some error", request, request.body());
+    }
+
+    private Request getFeignRequest() {
+        var emptyByteArray = new byte[]{};
+
+        return Request.create(
+            Request.HttpMethod.POST,
+            "/notify",
+            emptyMap(),
+            Request.Body.create(emptyByteArray),
+            null
+        );
     }
 }


### PR DESCRIPTION
### Change description ###

When something is unknown feign clients return status `-1` which fails to evaluate into Spring's `HttpStatus`. Using `resolve` method instead which returns null when status is not found

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
