### PR TITLE
Changed type of error_description

### DIFF
--- a/src/main/resources/db/migration/V006__Change_error_description_type.sql
+++ b/src/main/resources/db/migration/V006__Change_error_description_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notifications
+ALTER COLUMN error_description TEXT;

--- a/src/main/resources/db/migration/V006__Change_error_description_type.sql
+++ b/src/main/resources/db/migration/V006__Change_error_description_type.sql
@@ -1,2 +1,2 @@
 ALTER TABLE notifications
-ALTER COLUMN error_description TEXT;
+ALTER COLUMN error_description TYPE TEXT;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1087


### Change description ###
Type of 'reason' field in process_events table in the processor DB is TEXT (nullable). Type of 'error_description' field in notifications table is VARCHAR(255) (non-nullable). It appeared that some values in 'reason' field in processor DB exceed 255 characters, this prevents import of existing notifications from processor.

Suggestion is to change type of 'error_description' field to TEXT (non-nullable, because there are no NULL values in 'reason' field in processor DB).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
