### PR TITLE
use staging queue for testing

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -21,8 +21,8 @@ so for testing purposes it makes sense to use as an example.
  */
 def nonPrSecrets = [
   'reform-scan-${env}': [
-    secret('notifications-queue-listen-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_READ'),
-    secret('notifications-queue-send-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_WRITE')
+    secret('notifications-staging-queue-listen-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_READ'),
+    secret('notifications-staging-queue-send-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_WRITE')
   ],
   's2s-${env}': [
     secret('microservicekey-bulk-scan-processor-tests', 'TEST_S2S_SECRET')

--- a/charts/reform-scan-notification-service/Chart.yaml
+++ b/charts/reform-scan-notification-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Reform Scan Notification Service
 name: reform-scan-notification-service
 home: https://github.com/hmcts/reform-scan-notification-service
-version: 0.0.10
+version: 0.0.11
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-notification-service/values.aat.template.yaml
+++ b/charts/reform-scan-notification-service/values.aat.template.yaml
@@ -4,3 +4,19 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     NOTIFICATIONS_CONSUME_TASK_DELAY_IN_MS: 1000
+    STAGING_QUEUE_NOTIFICATIONS_ENABLED: true
+    QUEUE_NOTIFICATIONS_READ: false
+  keyVaults:
+    reform-scan:
+      resourceGroup: reform-scan
+      secrets:
+        - app-insights-instrumentation-key
+        - error-notifications-password
+        - error-notifications-url
+        - error-notifications-username
+        - notification-service-POSTGRES-PASS
+        - notification-service-POSTGRES-USER
+        - notification-service-POSTGRES-HOST
+        - notification-service-POSTGRES-PORT
+        - notification-service-POSTGRES-DATABASE
+        - notifications-staging-queue-listen-connection-string

--- a/charts/reform-scan-notification-service/values.yaml
+++ b/charts/reform-scan-notification-service/values.yaml
@@ -16,6 +16,7 @@ java:
         - notification-service-POSTGRES-PORT
         - notification-service-POSTGRES-DATABASE
         - notifications-queue-listen-connection-string
+        - notifications-staging-queue-listen-connection-string
 
   environment:
     DB_CONN_OPTIONS: ?sslmode=require
@@ -26,6 +27,7 @@ java:
     NOTIFICATIONS_CONSUME_TASK_ENABLED: true
     PENDING_NOTIFICATIONS_TASK_DELAY_IN_MS: 500
     PENDING_NOTIFICATIONS_TASK_ENABLED: true
+    STAGING_QUEUE_NOTIFICATIONS_ENABLED: false
   image: 'hmctspublic.azurecr.io/reform-scan/notification-service:latest'
 servicebus:
   enabled: false

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/config/QueueClientConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/config/QueueClientConfig.java
@@ -24,4 +24,14 @@ public class QueueClientConfig {
         );
     }
 
+    @Bean
+    @ConditionalOnProperty(name = "queue.notifications.staging-enabled")
+    public IMessageReceiver notificationsTestMessageReceiver(
+        @Value("${queue.notifications.staging-read-connection-string}") String connectionString)
+        throws InterruptedException, ServiceBusException {
+        return ClientFactory.createMessageReceiverFromConnectionString(
+            connectionString,
+            ReceiveMode.PEEKLOCK
+        );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,8 @@ flyway:
 queue:
   notifications:
     read-connection-string: ${QUEUE_NOTIFICATIONS_READ}
+    staging-read-connection-string: ${STAGING_QUEUE_NOTIFICATIONS_READ:}
+    staging-enabled:  ${STAGING_QUEUE_NOTIFICATIONS_ENABLED:false}
     max-delivery-count: ${QUEUE_NOTIFICATIONS_MAX_RETRY}
 
 scheduling:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,8 +34,8 @@ flyway:
 queue:
   notifications:
     read-connection-string: ${QUEUE_NOTIFICATIONS_READ}
-    staging-read-connection-string: ${STAGING_QUEUE_NOTIFICATIONS_READ:}
-    staging-enabled:  ${STAGING_QUEUE_NOTIFICATIONS_ENABLED:false}
+    staging-read-connection-string: ${STAGING_QUEUE_NOTIFICATIONS_READ}
+    staging-enabled:  ${STAGING_QUEUE_NOTIFICATIONS_ENABLED}
     max-delivery-count: ${QUEUE_NOTIFICATIONS_MAX_RETRY}
 
 scheduling:

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -16,3 +16,4 @@ spring:
         notification-service-POSTGRES-HOST: DB_HOST
         notification-service-POSTGRES-PORT: DB_PORT
         notifications-queue-listen-connection-string: QUEUE_NOTIFICATIONS_READ
+        notifications-staging-queue-listen-connection-string: STAGING_QUEUE_NOTIFICATIONS_READ


### PR DESCRIPTION

### Change description ###

use staging queue for testing.
just use the staging queue for aat-staging. default false.
I did not want to use missing bean condition or not want to use default queues connection-string in test queue condition, I want explicit configuration so create 'queue.notifications.staging-enabled' var. 

will update flux just before merge.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
