### PR TITLE
Rename envelope api info model property

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/notificationservice/ProcessNotificationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/notificationservice/ProcessNotificationTest.java
@@ -49,7 +49,7 @@ class ProcessNotificationTest {
             .hasSize(1)
             .first()
             .satisfies(node -> {
-                assertThat(node.get("notification_id").asText()).isNotEmpty();
+                assertThat(node.get("confirmation_id").asText()).isNotEmpty();
                 assertThat(node.get("zip_file_name").asText()).isEqualTo(messageDetails.zipFileName);
                 assertThat(node.get("service").asText()).isEqualTo(messageDetails.service);
                 // following fields will have to be amended in case notification test API starts to accept our requests

--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/controller/NotificationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/controller/NotificationControllerTest.java
@@ -59,7 +59,7 @@ public class NotificationControllerTest extends ControllerTestBase {
 
         var notification1 = new Notification(
             1L,
-            "notificationId1",
+            "confirmation-id-1",
             fileName,
             "po_box1",
             "container",
@@ -73,7 +73,7 @@ public class NotificationControllerTest extends ControllerTestBase {
         );
         var notification2 = new Notification(
             2L,
-            "notificationId2",
+            "confirmation-id-2",
             fileName,
             "po_box2",
             "container",
@@ -101,7 +101,7 @@ public class NotificationControllerTest extends ControllerTestBase {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.count", is(2)))
             .andExpect(jsonPath("$.notifications", hasSize(2)))
-            .andExpect(jsonPath("$.notifications[0].notification_id").value(notification1.confirmationId))
+            .andExpect(jsonPath("$.notifications[0].confirmation_id").value(notification1.confirmationId))
             .andExpect(jsonPath("$.notifications[0].zip_file_name").value(notification1.zipFileName))
             .andExpect(jsonPath("$.notifications[0].po_box").value(notification1.poBox))
             .andExpect(jsonPath("$.notifications[0].container").value(notification1.container))
@@ -112,7 +112,7 @@ public class NotificationControllerTest extends ControllerTestBase {
             .andExpect(jsonPath("$.notifications[0].created_at").value(instantString))
             .andExpect(jsonPath("$.notifications[0].processed_at").value(instantString))
             .andExpect(jsonPath("$.notifications[0].status").value(notification1.status.name()))
-            .andExpect(jsonPath("$.notifications[1].notification_id").value(notification2.confirmationId))
+            .andExpect(jsonPath("$.notifications[1].confirmation_id").value(notification2.confirmationId))
             .andExpect(jsonPath("$.notifications[1].zip_file_name").value(notification2.zipFileName))
             .andExpect(jsonPath("$.notifications[1].po_box").value(notification2.poBox))
             .andExpect(jsonPath("$.notifications[1].container").value(notification2.container))

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/model/out/NotificationInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/model/out/NotificationInfo.java
@@ -7,8 +7,8 @@ import uk.gov.hmcts.reform.notificationservice.util.CustomInstantSerializer;
 import java.time.Instant;
 
 public class NotificationInfo {
-    @JsonProperty("notification_id")
-    public final String notificationId;
+    @JsonProperty("confirmation_id")
+    public final String confirmationId;
 
     @JsonProperty("zip_file_name")
     public final String zipFileName;
@@ -40,7 +40,7 @@ public class NotificationInfo {
     public final String status;
 
     public NotificationInfo(
-        String notificationId,
+        String confirmationId,
         String zipFileName,
         String poBox,
         String container,
@@ -51,7 +51,7 @@ public class NotificationInfo {
         Instant processedAt,
         String status
     ) {
-        this.notificationId = notificationId;
+        this.confirmationId = confirmationId;
         this.zipFileName = zipFileName;
         this.poBox = poBox;
         this.container = container;


### PR DESCRIPTION
Following changes from https://github.com/hmcts/reform-scan-notification-service/pull/84