### PR TITLE
Bump java chart 2.15 -> 2.18

### DIFF
--- a/charts/reform-scan-notification-service/Chart.yaml
+++ b/charts/reform-scan-notification-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Reform Scan Notification Service
 name: reform-scan-notification-service
 home: https://github.com/hmcts/reform-scan-notification-service
-version: 0.0.13
+version: 0.1.0
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/charts/reform-scan-notification-service/requirements.yaml
+++ b/charts/reform-scan-notification-service/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: java
-    version: ~2.16.1
+    version: ~2.18.0
     repository: '@hmctspublic'
   - name: servicebus
     version: ~0.2.2


### PR DESCRIPTION
### Change description ###

This introduces next iteration (instead of bug-fix), but since it's still v0 so moving to the v.0.1 instead. Fresh start for chart - comes with the smoke/functional test feature for flux manager.

So any next iteration can be treated freshly as mostly we introduce some flags and whatnot which is sort of minor version release

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
