### PR TITLE
Amend log entry marking task ending

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/task/NotificationMessageProcessTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/task/NotificationMessageProcessTask.java
@@ -33,14 +33,14 @@ public class NotificationMessageProcessTask {
             do {
                 queueMayHaveMessages = notificationMessageProcessor.processNextMessage();
             } while (queueMayHaveMessages);
-
-            log.info("Finished {} task", TASK_NAME);
         } catch (InterruptedException exception) {
             logTaskError(exception);
             Thread.currentThread().interrupt();
         } catch (ServiceBusException exception) {
             logTaskError(exception);
         }
+
+        log.info("Finished {} task", TASK_NAME);
     }
 
     private void logTaskError(Exception exception) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

Not quite related, but still: [Create alerts for scheduled tasks in Notification service](https://tools.hmcts.net/jira/browse/BPS-1190)

### Change description ###

Making sure log entry is marking the end of task of consuming service bus notifications

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
