### PR TITLE
Change timestamp format in api endpoints

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/controller/NotificationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/controller/NotificationControllerTest.java
@@ -15,9 +15,11 @@ import uk.gov.hmcts.reform.notificationservice.service.NotificationService;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -47,6 +49,7 @@ public class NotificationControllerTest {
         final String service = "service";
 
         Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("Europe/London"));
         cal.set(Calendar.YEAR, 2020);
         cal.set(Calendar.MONTH, Calendar.MARCH);
         cal.set(Calendar.DATE, 23);
@@ -55,7 +58,7 @@ public class NotificationControllerTest {
         cal.set(Calendar.SECOND, 20);
         cal.set(Calendar.MILLISECOND, 234);
         Instant instant = cal.toInstant();
-        final String instantString = "2020-03-23T13:17:20.234Z";
+        final String instantString = "2020-03-23T13:17:20";
 
         var notification1 = new Notification(
             1L,
@@ -202,8 +205,8 @@ public class NotificationControllerTest {
         LocalDate date = LocalDate.now();
         Instant instantNow = date.atStartOfDay(ZoneOffset.UTC).toInstant();
 
-        String instantNowStr = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-            .withZone(ZoneOffset.UTC)
+        String instantNowStr = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .withZone(ZoneId.of("Europe/London"))
             .format(instantNow);
 
         var notification1 = new Notification(

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/util/DateFormatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/util/DateFormatter.java
@@ -5,15 +5,13 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static java.time.ZoneOffset.UTC;
-
 final class DateFormatter {
 
-    private static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    private static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATETIME_PATTERN);
 
     static String getSimpleDateTime(final Instant instant) {
-        return formatter.format(ZonedDateTime.ofInstant(instant, ZoneId.from(UTC)));
+        return formatter.format(ZonedDateTime.ofInstant(instant, ZoneId.of("Europe/London")));
     }
 
     private DateFormatter() {

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/util/CustomInstantSerializerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/util/CustomInstantSerializerTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ class CustomInstantSerializerTest {
     void serialize_should_call_json_generator() throws Exception {
         // given
         Calendar cal   = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("Europe/London"));
         cal.set(Calendar.YEAR, 2020);
         cal.set(Calendar.MONTH, Calendar.MARCH);
         cal.set(Calendar.DATE, 23);
@@ -49,6 +51,6 @@ class CustomInstantSerializerTest {
         // then
         var dateStringCaptor = ArgumentCaptor.forClass(String.class);
         verify(jsonGenerator).writeString(dateStringCaptor.capture());
-        assertThat(dateStringCaptor.getValue()).isEqualTo("2020-03-23T13:17:20.234Z");
+        assertThat(dateStringCaptor.getValue()).isEqualTo("2020-03-23T13:17:20");
     }
 }


### PR DESCRIPTION
- Use local time instead of UTC
- remove miliseconds

Changes are applied in the `DateFormatter` class which is used by `CustomInstantSerializer`, which is used in annotations on response models datetime fields:

```java
@JsonSerialize(using = CustomInstantSerializer.class)
```

https://tools.hmcts.net/jira/browse/BPS-1284