### PR TITLE
Populate message_id values in the notifications table

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -73,7 +73,8 @@ public class NotificationRepositoryTest {
             service,
             "dcn",
             ErrorCode.ERR_AV_FAILED,
-            "error_description"
+            "error_description",
+            "123456"
         );
 
         // when
@@ -114,7 +115,8 @@ public class NotificationRepositoryTest {
             service,
             "dcn1",
             ErrorCode.ERR_AV_FAILED,
-            "error_description1"
+            "error_description1",
+            "12345"
         );
         final var newNotificationFromOtherService = new NewNotification(
             zipFileName,
@@ -123,7 +125,8 @@ public class NotificationRepositoryTest {
             "other_service",
             "dcn2",
             ErrorCode.ERR_FILE_LIMIT_EXCEEDED,
-            "error_description2"
+            "error_description2",
+            "1234445"
         );
         final var newNotification3 = new NewNotification(
             zipFileName,
@@ -132,7 +135,8 @@ public class NotificationRepositoryTest {
             service,
             "dcn3",
             ErrorCode.ERR_METAFILE_INVALID,
-            "error_description3"
+            "error_description3",
+            "124355676"
         );
 
         // when
@@ -194,7 +198,8 @@ public class NotificationRepositoryTest {
             service,
             "dcn1",
             ErrorCode.ERR_AV_FAILED,
-            "error_description1"
+            "error_description1",
+            "1234555"
         );
         final var newNotificationForOtherZipFile = new NewNotification(
             "other_zip_file_name",
@@ -203,7 +208,8 @@ public class NotificationRepositoryTest {
             service,
             "dcn2",
             ErrorCode.ERR_FILE_LIMIT_EXCEEDED,
-            "error_description2"
+            "error_description2",
+            "12121331"
         );
         final var newNotification3 = new NewNotification(
             zipFileName,
@@ -212,7 +218,8 @@ public class NotificationRepositoryTest {
             service,
             "dcn3",
             ErrorCode.ERR_METAFILE_INVALID,
-            "error_description3"
+            "error_description3",
+            "54321"
         );
 
         // when
@@ -365,7 +372,8 @@ public class NotificationRepositoryTest {
             "other_service",
             "dcn2",
             ErrorCode.ERR_FILE_LIMIT_EXCEEDED,
-            "error_description2"
+            "error_description2",
+            "123455"
         );
         notificationRepository.insert(newNotification);
 
@@ -405,7 +413,8 @@ public class NotificationRepositoryTest {
             "service",
             "dcn",
             ErrorCode.ERR_AV_FAILED,
-            "error_description"
+            "error_description",
+            "124356"
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NewNotification.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NewNotification.java
@@ -13,6 +13,7 @@ public class NewNotification {
     public final String errorDescription;
     public final String messageId;
 
+    @SuppressWarnings("squid:S00107") // number of params
     public NewNotification(
         String zipFileName,
         String poBox,

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NewNotification.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NewNotification.java
@@ -11,6 +11,7 @@ public class NewNotification {
     public final String documentControlNumber;
     public final ErrorCode errorCode;
     public final String errorDescription;
+    public final String messageId;
 
     public NewNotification(
         String zipFileName,
@@ -19,7 +20,8 @@ public class NewNotification {
         String service,
         String documentControlNumber,
         ErrorCode errorCode,
-        String errorDescription
+        String errorDescription,
+        String messageId
     ) {
         this.zipFileName = zipFileName;
         this.poBox = poBox;
@@ -28,5 +30,6 @@ public class NewNotification {
         this.documentControlNumber = documentControlNumber;
         this.errorCode = errorCode;
         this.errorDescription = errorDescription;
+        this.messageId = messageId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageHandler.java
@@ -22,10 +22,10 @@ public class NotificationMessageHandler {
     }
 
 
-    public void handleNotificationMessage(NotificationMsg notificationMsg) {
+    public void handleNotificationMessage(NotificationMsg notificationMsg, String messageId) {
         log.info("Handle notification message, Zip File: {}", notificationMsg.zipFileName);
 
-        var newNotification = notificationMessageMapper.map(notificationMsg);
+        var newNotification = notificationMessageMapper.map(notificationMsg, messageId);
 
         long id = notificationRepository.insert(newNotification);
         log.info(

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageMapper.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.reform.notificationservice.model.in.NotificationMsg;
 @Component
 public class NotificationMessageMapper {
 
-    public NewNotification map(NotificationMsg notificationMsg) {
+    public NewNotification map(NotificationMsg notificationMsg, String messageId) {
         return new NewNotification(
             notificationMsg.zipFileName,
             notificationMsg.poBox,
@@ -15,7 +15,8 @@ public class NotificationMessageMapper {
             notificationMsg.service,
             notificationMsg.documentControlNumber,
             notificationMsg.errorCode,
-            notificationMsg.errorDescription
+            notificationMsg.errorDescription,
+            messageId
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageProcessor.java
@@ -43,7 +43,7 @@ public class NotificationMessageProcessor {
             try {
                 log.info("Started processing notification message with ID {}", message.getMessageId());
                 var notificationMsg = notificationMessageParser.parse(message.getMessageBody());
-                notificationMessageHandler.handleNotificationMessage(notificationMsg);
+                notificationMessageHandler.handleNotificationMessage(notificationMsg, message.getMessageId());
                 finaliseProcessedMessage(message, MessageProcessingResult.SUCCESS);
             } catch (InvalidMessageException ex) {
                 log.error("Invalid notification message with ID: {} ", message.getMessageId(), ex);

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageHandlerTest.java
@@ -49,6 +49,7 @@ public class NotificationMessageHandlerTest {
                 "processor"
             );
 
+        String messageId = "message12345";
         NewNotification newNotification =
             new NewNotification(
                 "Zipfile.zip",
@@ -57,17 +58,18 @@ public class NotificationMessageHandlerTest {
                 "processor",
                 "A1342411414214",
                 ErrorCode.ERR_AV_FAILED,
-                "error description Av not valid"
+                "error description Av not valid",
+                messageId
             );
 
-        when(notificationMessageMapper.map(notificationMsg)).thenReturn(newNotification);
+        when(notificationMessageMapper.map(notificationMsg, messageId)).thenReturn(newNotification);
         when(notificationRepository.insert(newNotification))
             .thenReturn(21321312L);
 
-        notificationMessageHandler.handleNotificationMessage(notificationMsg);
+        notificationMessageHandler.handleNotificationMessage(notificationMsg, messageId);
 
         // then
-        verify(notificationMessageMapper).map(notificationMsg);
+        verify(notificationMessageMapper).map(notificationMsg, messageId);
         verify(notificationRepository).insert(newNotification);
     }
 
@@ -85,6 +87,7 @@ public class NotificationMessageHandlerTest {
                 "processor"
             );
 
+        String messageId = "123567";
         NewNotification newNotification =
             new NewNotification(
                 "file.txt",
@@ -93,21 +96,22 @@ public class NotificationMessageHandlerTest {
                 "processor",
                 "32313223",
                 ErrorCode.ERR_SERVICE_DISABLED,
-                "error description service disabled"
+                "error description service disabled",
+                messageId
             );
 
 
-        when(notificationMessageMapper.map(notificationMsg)).thenReturn(newNotification);
+        when(notificationMessageMapper.map(notificationMsg, messageId)).thenReturn(newNotification);
 
         FeignException exception = mock(FeignException.class);
         doThrow(exception).when(notificationRepository).insert(newNotification);
 
         // when
-        assertThatThrownBy(() -> notificationMessageHandler.handleNotificationMessage(notificationMsg))
+        assertThatThrownBy(() -> notificationMessageHandler.handleNotificationMessage(notificationMsg, messageId))
             .isSameAs(exception);
 
         // then
-        verify(notificationMessageMapper).map(notificationMsg);
+        verify(notificationMessageMapper).map(notificationMsg, messageId);
         verify(notificationRepository).insert(newNotification);
     }
 
@@ -125,15 +129,16 @@ public class NotificationMessageHandlerTest {
                 "processor"
             );
 
+        String messageId = "12345677";
         InvalidMessageException exception = new InvalidMessageException("Parsed Failed");
-        doThrow(exception).when(notificationMessageMapper).map(notificationMsg);
+        doThrow(exception).when(notificationMessageMapper).map(notificationMsg, messageId);
 
         // when
-        assertThatThrownBy(() -> notificationMessageHandler.handleNotificationMessage(notificationMsg))
+        assertThatThrownBy(() -> notificationMessageHandler.handleNotificationMessage(notificationMsg, messageId))
             .isSameAs(exception);
 
         // then
-        verify(notificationMessageMapper).map(notificationMsg);
+        verify(notificationMessageMapper).map(notificationMsg, messageId);
         verifyNoMoreInteractions(notificationRepository);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationMessageMapperTest.java
@@ -25,7 +25,7 @@ public class NotificationMessageMapperTest {
                 "orchestrator"
             );
 
-        NewNotification request = notificationMessageMapper.map(notificationMsg);
+        NewNotification request = notificationMessageMapper.map(notificationMsg, "1234");
         assertThat(request.zipFileName).isEqualTo("zipfile.zip");
         assertThat(request.poBox).isEqualTo("pobox");
         assertThat(request.documentControlNumber).isEqualTo("1342411414214");


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1291


### Change description ###
- Populate `message_id` column in the `notifications` table values with the queue message id 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
