### PR TITLE
Populate null message id values and add unique constraint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.notificationservice.model.common.ErrorCode;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.notificationservice.data.NotificationStatus.FAILED;
@@ -422,7 +423,7 @@ public class NotificationRepositoryTest {
             "dcn",
             ErrorCode.ERR_AV_FAILED,
             "error_description",
-            "124356"
+            UUID.randomUUID().toString()
         );
     }
 }

--- a/src/main/resources/db/migration/V009__populate-message-id-values-add-unique-constraint.sql
+++ b/src/main/resources/db/migration/V009__populate-message-id-values-add-unique-constraint.sql
@@ -2,4 +2,5 @@ UPDATE notifications SET message_id = CONCAT('legacy_', id)
   WHERE message_id IS NULL;
 
 ALTER TABLE notifications
+  ALTER COLUMN message_id SET NOT NULL,
   ADD CONSTRAINT notifications_message_id UNIQUE (message_id);

--- a/src/main/resources/db/migration/V009__populate-message-id-values-add-unique-constraint.sql
+++ b/src/main/resources/db/migration/V009__populate-message-id-values-add-unique-constraint.sql
@@ -1,5 +1,5 @@
 UPDATE notifications SET message_id = CONCAT('legacy_', id)
-  WHERE message_id IS NULL
+  WHERE message_id IS NULL;
 
 ALTER TABLE notifications
   ADD CONSTRAINT notifications_message_id UNIQUE (message_id);

--- a/src/main/resources/db/migration/V009__populate-message-id-values-add-unique-constraint.sql
+++ b/src/main/resources/db/migration/V009__populate-message-id-values-add-unique-constraint.sql
@@ -1,0 +1,5 @@
+UPDATE notifications SET message_id = CONCAT('legacy_', id)
+  WHERE message_id IS NULL
+
+ALTER TABLE notifications
+  ADD CONSTRAINT notifications_message_id UNIQUE (message_id);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1291

### Change description ###
- Populate `message_id` column values for the old records where `message_id` is null.
- Add unique constraint on `message_id` 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
