### PR TITLE
Update Notification repository to include message_id to the sql

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/controller/NotificationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/controller/NotificationControllerTest.java
@@ -72,7 +72,8 @@ public class NotificationControllerTest {
             "invalid metafile1",
             instant,
             instant,
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId1"
         );
         var notification2 = new Notification(
             2L,
@@ -86,7 +87,8 @@ public class NotificationControllerTest {
             "invalid metafile2",
             instant,
             instant,
-            NotificationStatus.MANUALLY_HANDLED
+            NotificationStatus.MANUALLY_HANDLED,
+            "messageId2"
         );
 
         given(authService.authenticate(auth)).willReturn(service);
@@ -221,7 +223,8 @@ public class NotificationControllerTest {
             "invalid metafile1",
             instantNow,
             instantNow,
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId1"
         );
         var notification2 = new Notification(
             2L,
@@ -235,7 +238,8 @@ public class NotificationControllerTest {
             "invalid metafile_2",
             instantNow,
             instantNow,
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId2"
         );
 
         given(notificationService.findByDate(date))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -52,6 +52,7 @@ public class NotificationRepositoryTest {
                 assertThat(n.createdAt).isNotNull();
                 assertThat(n.processedAt).isNull();
                 assertThat(n.status).isEqualTo(PENDING);
+                assertThat(n.messageId).isEqualTo(newNotification.messageId);
             });
     }
 
@@ -99,6 +100,7 @@ public class NotificationRepositoryTest {
                 assertThat(n.createdAt).isNotNull();
                 assertThat(n.processedAt).isNull();
                 assertThat(n.status).isEqualTo(PENDING);
+                assertThat(n.messageId).isEqualTo(newNotification.messageId);
             });
     }
 
@@ -165,7 +167,8 @@ public class NotificationRepositoryTest {
                     newNotification1.errorDescription,
                     null,
                     null,
-                    PENDING
+                    PENDING,
+                    newNotification1.messageId
                 ),
                 new Notification(
                     id3,
@@ -179,7 +182,8 @@ public class NotificationRepositoryTest {
                     newNotification3.errorDescription,
                     null,
                     null,
-                    PENDING
+                    PENDING,
+                    newNotification3.messageId
                 )
             )
         ;
@@ -248,7 +252,8 @@ public class NotificationRepositoryTest {
                     newNotification1.errorDescription,
                     null,
                     null,
-                    PENDING
+                    PENDING,
+                    newNotification1.messageId
                 ),
                 new Notification(
                     id3,
@@ -262,7 +267,8 @@ public class NotificationRepositoryTest {
                     newNotification3.errorDescription,
                     null,
                     null,
-                    PENDING
+                    PENDING,
+                    newNotification3.messageId
                 )
             )
         ;
@@ -296,6 +302,7 @@ public class NotificationRepositoryTest {
             .satisfies(notification -> {
                 assertThat(notification.id).isEqualTo(idPending);
                 assertThat(notification.status).isEqualTo(PENDING);
+                assertThat(notification.messageId).isEqualTo(newNotification.messageId);
                 assertThat(notification.confirmationId).isNull();
             });
     }
@@ -402,6 +409,7 @@ public class NotificationRepositoryTest {
                 assertThat(n.createdAt).isNotNull();
                 assertThat(n.processedAt).isNull();
                 assertThat(n.status).isEqualTo(PENDING);
+                assertThat(n.messageId).isEqualTo(newNotification.messageId);
             });
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/Notification.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/Notification.java
@@ -18,6 +18,7 @@ public class Notification {
     public final Instant createdAt;
     public final Instant processedAt;
     public final NotificationStatus status;
+    public final String messageId;
 
     public Notification(
         long id,
@@ -31,7 +32,8 @@ public class Notification {
         String errorDescription,
         Instant createdAt,
         Instant processedAt,
-        NotificationStatus status
+        NotificationStatus status,
+        String messageId
     ) {
         this.id = id;
         this.confirmationId = confirmationId;
@@ -45,6 +47,7 @@ public class Notification {
         this.createdAt = createdAt;
         this.processedAt = processedAt;
         this.status = status;
+        this.messageId = messageId;
     }
 
     public String basicInfo() {

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationMapper.java
@@ -26,7 +26,8 @@ public class NotificationMapper implements RowMapper<Notification> {
             rs.getString("error_description"),
             rs.getTimestamp("created_at").toInstant(),
             getOptionalInstant(rs.getTimestamp("processed_at")),
-            NotificationStatus.valueOf(rs.getString("status"))
+            NotificationStatus.valueOf(rs.getString("status")),
+            rs.getString("message_id")
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepository.java
@@ -75,9 +75,9 @@ public class NotificationRepository {
 
         jdbcTemplate.update(
             "INSERT INTO notifications (zip_file_name, po_box, container, service, document_control_number, "
-                + "error_code, error_description, created_at, status) "
+                + "error_code, error_description, created_at, status, message_id) "
                 + "VALUES ( :zipFileName, :poBox, :container, :service, :DCN, :errorCode, "
-                + ":errorDescription, CURRENT_TIMESTAMP, :status"
+                + ":errorDescription, CURRENT_TIMESTAMP, :status, :messageId"
                 + ")",
             new MapSqlParameterSource()
                 .addValue("zipFileName", notification.zipFileName)
@@ -87,7 +87,8 @@ public class NotificationRepository {
                 .addValue("DCN", notification.documentControlNumber)
                 .addValue("errorCode", notification.errorCode.name())
                 .addValue("errorDescription", notification.errorDescription)
-                .addValue("status", PENDING.name()),
+                .addValue("status", PENDING.name())
+                .addValue("messageId", notification.messageId),
             keyHolder,
             new String[]{ "id" }
         );

--- a/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/notificationservice/service/NotificationServiceTest.java
@@ -146,7 +146,8 @@ class NotificationServiceTest {
             "invalid metafile1",
             Instant.now(),
             Instant.now(),
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId1"
         );
         var notification2 = new Notification(
             2L,
@@ -160,7 +161,8 @@ class NotificationServiceTest {
             "invalid metafile2",
             Instant.now(),
             Instant.now(),
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId2"
         );
         given(notificationRepository.find(zipFileName, service))
                   .willReturn(asList(notification1, notification2));
@@ -182,7 +184,8 @@ class NotificationServiceTest {
                     notification1.errorCode,
                     notification1.createdAt,
                     notification1.processedAt,
-                    notification1.status
+                    notification1.status,
+                    notification1.messageId
                 ),
                 tuple(
                     notification2.confirmationId,
@@ -193,7 +196,8 @@ class NotificationServiceTest {
                     notification2.errorCode,
                     notification2.createdAt,
                     notification2.processedAt,
-                    notification2.status
+                    notification2.status,
+                    notification2.messageId
                 )
             );
         verify(notificationRepository, times(1)).find(zipFileName, service);
@@ -218,7 +222,8 @@ class NotificationServiceTest {
             "invalid metafile1",
             Instant.now(),
             Instant.now(),
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId1"
         );
         var notification2 = new Notification(
             2L,
@@ -232,7 +237,8 @@ class NotificationServiceTest {
             "invalid metafile2",
             Instant.now(),
             Instant.now(),
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId2"
         );
         given(notificationRepository.find(zipFileNameCleanedUp, service))
                   .willReturn(asList(notification1, notification2));
@@ -254,7 +260,8 @@ class NotificationServiceTest {
                     notification1.errorCode,
                     notification1.createdAt,
                     notification1.processedAt,
-                    notification1.status
+                    notification1.status,
+                    notification1.messageId
                 ),
                 tuple(
                     notification2.confirmationId,
@@ -265,7 +272,8 @@ class NotificationServiceTest {
                     notification2.errorCode,
                     notification2.createdAt,
                     notification2.processedAt,
-                    notification2.status
+                    notification2.status,
+                    notification2.messageId
                 )
             );
         verify(notificationRepository, times(1)).find(zipFileNameCleanedUp, service);
@@ -289,7 +297,8 @@ class NotificationServiceTest {
             "invalid metafile_1",
             Instant.now(),
             Instant.now(),
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId1"
         );
         var notification2 = new Notification(
             2L,
@@ -303,7 +312,8 @@ class NotificationServiceTest {
             "invalid metafile_2",
             Instant.now(),
             Instant.now(),
-            NotificationStatus.SENT
+            NotificationStatus.SENT,
+            "messageId1"
         );
         given(notificationRepository.findByDate(searchDate))
             .willReturn(asList(notification1, notification2));
@@ -331,7 +341,8 @@ class NotificationServiceTest {
             notification.errorCode,
             notification.createdAt,
             notification.processedAt,
-            notification.status
+            notification.status,
+            notification.messageId
         );
     }
 
@@ -348,7 +359,8 @@ class NotificationServiceTest {
             "invalid metafile",
             Instant.now(),
             null,
-            NotificationStatus.PENDING
+            NotificationStatus.PENDING,
+            "messageId1"
         );
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1291


### Change description ###
`NotificationRespository` changes are missing in #190 
Add `message_id` to insert SQL statement to populate values.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
