### PR TITLE
Replace ServiceBus connection string with access key in functional tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,8 +16,7 @@ GradleBuilder builder = new GradleBuilder(this, product)
 
 def nonPrSecrets = [
   'reform-scan-${env}': [
-    secret('notifications-staging-queue-listen-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_READ'),
-    secret('notifications-staging-queue-send-connection-string', 'NOTIFICATION_QUEUE_CONN_STRING_WRITE'),
+    secret('notifications-staging-queue-send-shared-access-key', 'NOTIFICATION_QUEUE_ACCESS_KEY_WRITE'),
     secret('test-s2s-secret', 'TEST_S2S_SECRET')
   ]
 ]
@@ -45,6 +44,9 @@ withPipeline(type, product, component) {
   after('akschartsinstall') {
     // Vars needed for AKS testing
     env.TEST_S2S_URL = 'http://rpe-service-auth-provider-aat.service.core-compute-aat.internal'
+    env.NOTIFICATION_QUEUE_NAME = "notifications-staging"
+    env.NOTIFICATION_QUEUE_NAMESPACE = "reform-scan-servicebus-aat"
+    env.NOTIFICATION_QUEUE_ACCESS_KEY_NAME_WRITE = "SendSharedAccessKey"
   }
 
   before('smoketest:preview') {
@@ -60,10 +62,10 @@ withPipeline(type, product, component) {
       def kubectl = new Kubectl(this, subscription, namespace)
       kubectl.login()
 
-      // Get notifications queue connection string
-      def sbConnectionStr = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.connectionString}")
-      env.NOTIFICATION_QUEUE_CONN_STRING_READ = "${sbConnectionStr};EntityPath=notifications"
-      env.NOTIFICATION_QUEUE_CONN_STRING_WRITE = "${sbConnectionStr};EntityPath=notifications"
+      env.NOTIFICATION_QUEUE_NAME = "notifications"
+      env.NOTIFICATION_QUEUE_NAMESPACE = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.namespaceName}")
+      env.NOTIFICATION_QUEUE_ACCESS_KEY_WRITE = kubectl.getSecret(sbNamespaceSecret, namespace, "{.data.primaryKey}")
+      env.NOTIFICATION_QUEUE_ACCESS_KEY_NAME_WRITE = "RootManageSharedAccessKey"
     }
   }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,7 +16,7 @@ GradleBuilder builder = new GradleBuilder(this, product)
 
 def nonPrSecrets = [
   'reform-scan-${env}': [
-    secret('notifications-staging-queue-send-shared-access-key', 'NOTIFICATION_QUEUE_ACCESS_KEY_WRITE'),
+    secret('notification-staging-queue-send-shared-access-key', 'NOTIFICATION_QUEUE_ACCESS_KEY_WRITE'),
     secret('test-s2s-secret', 'TEST_S2S_SECRET')
   ]
 ]

--- a/src/functionalTest/java/uk/gov/hmcts/reform/notificationservice/Configuration.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/notificationservice/Configuration.java
@@ -16,10 +16,14 @@ final class Configuration {
     static final String TEST_URL = CONFIG.getString("test-url");
     static final String TEST_S2S_SECRET = CONFIG.getString("test-s2s-secret");
     static final String TEST_S2S_URL = CONFIG.getString("test-s2s-url");
-    static final String NOTIFICATION_QUEUE_CONN_STRING_READ = CONFIG
-        .getString("test-notification-queue-connection-string-read");
-    static final String NOTIFICATION_QUEUE_CONN_STRING_WRITE = CONFIG
-        .getString("test-notification-queue-connection-string-write");
+    static final String NOTIFICATION_QUEUE_ACCESS_KEY_WRITE = CONFIG
+        .getString("test-notification-queue-access-key-write");
+    static final String NOTIFICATION_QUEUE_ACCESS_KEY_NAME_WRITE = CONFIG
+        .getString("test-notification-queue-access-key-name-write");
+    static final String NOTIFICATION_QUEUE_NAME = CONFIG
+        .getString("test-notification-queue-name");
+    static final String NOTIFICATION_QUEUE_NAMESPACE = CONFIG
+        .getString("test-notification-queue-namespace");
 
     private Configuration() {
         // utility class construct
@@ -28,7 +32,12 @@ final class Configuration {
     static QueueClient getSendClient() {
         try {
             return new QueueClient(
-                new ConnectionStringBuilder(NOTIFICATION_QUEUE_CONN_STRING_WRITE),
+                new ConnectionStringBuilder(
+                    NOTIFICATION_QUEUE_NAMESPACE,
+                    NOTIFICATION_QUEUE_NAME,
+                    NOTIFICATION_QUEUE_ACCESS_KEY_NAME_WRITE,
+                    NOTIFICATION_QUEUE_ACCESS_KEY_WRITE
+                ),
                 ReceiveMode.PEEKLOCK
             );
         } catch (InterruptedException exception) {

--- a/src/functionalTest/resources/application.conf
+++ b/src/functionalTest/resources/application.conf
@@ -1,5 +1,7 @@
 test-url=${TEST_URL}
-test-notification-queue-connection-string-read=${NOTIFICATION_QUEUE_CONN_STRING_READ}
-test-notification-queue-connection-string-write=${NOTIFICATION_QUEUE_CONN_STRING_WRITE}
+test-notification-queue-access-key-write=${NOTIFICATION_QUEUE_ACCESS_KEY_WRITE}
+test-notification-queue-access-key-name-read=${NOTIFICATION_QUEUE_ACCESS_KEY_NAME_WRITE}
+test-notification-queue-name=${NOTIFICATION_QUEUE_NAME}
+test-notification-queue-namespace=${NOTIFICATION_QUEUE_NAMESPACE}
 test-s2s-secret=${TEST_S2S_SECRET}
 test-s2s-url=${TEST_S2S_URL}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve the way Service Bus clients are created](https://tools.hmcts.net/jira/browse/BPS-771)

### Change description ###

Reviewing functional tests. READ was not used - removed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
