### PR TITLE
Added db to readiness. Integration test

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/health/ReadinessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/health/ReadinessTest.java
@@ -33,7 +33,7 @@ class ReadinessTest {
     }
 
     @Test
-    void should_readiness_contain_db_status() throws Exception {
+    void readiness_should_contain_db_status() throws Exception {
         mockMvc
             .perform(
                 get("/health/readiness")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/health/ReadinessTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/health/ReadinessTest.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.notificationservice.health;
+
+import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class ReadinessTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @BeforeEach
+    void setUp() {
+        var filter = new WebRequestTrackingFilter();
+        filter.init(new MockFilterConfig());
+        mockMvc = webAppContextSetup(wac).addFilters(filter).build();
+    }
+
+    @Test
+    void should_readiness_contain_db_status() throws Exception {
+        mockMvc
+            .perform(
+                get("/health/readiness")
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("UP"))
+            .andExpect(jsonPath("$.components.db.status").value("UP"))
+        ;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ management:
       show-details: "always"
       group:
         readiness:
-          include: readinessState, db
+          include: db
   endpoints:
     web:
       base-path: /

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,9 @@ management:
   endpoint:
     health:
       show-details: "always"
+      group:
+        readiness:
+          include: readinessState, db
   endpoints:
     web:
       base-path: /


### PR DESCRIPTION
### JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/BPS-1347

The result of accessing /health/readiness endpoint looks like this:

{ "status": "UP", "components": { "db": { "status": "UP", "details": { "database": "PostgreSQL", "validationQuery": "isValid()" } }, "readinessState": { "status": "UP" } } }

**Does this PR introduce a breaking change? (check one with "x")**

[ ] Yes
[x] No