### PR TITLE
DTSPO-18175: Fix Owner cannot be found error

### DIFF
--- a/charts/reform-scan-notification-service/values.preview.template.yaml
+++ b/charts/reform-scan-notification-service/values.preview.template.yaml
@@ -52,7 +52,7 @@ servicebus:
   teamName: "BSP"
   location: uksouth
   serviceplan: basic
-  sbNamespace: reform-scan-sb-preview
+  sbNamespace: reform-scan-servicebus-preview
   setup:
     queues:
       - name: notifications

--- a/charts/reform-scan-notification-service/values.preview.template.yaml
+++ b/charts/reform-scan-notification-service/values.preview.template.yaml
@@ -42,6 +42,7 @@ java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
 
+
   postgresql:
     enabled: true
     postgresqlUsername: db_user


### PR DESCRIPTION
Linked to [DTSPO-18175](https://tools.hmcts.net/jira/browse/DTSPO-18175)

k get namespacesqueues.servicebus.azure.com
NAME                                                                READY   SEVERITY   REASON            MESSAGE
reform-scan-notification-service-pr-1573-servicebus-notifications   False   Warning    WaitingForOwner   Owner "reform-scan-sb-preview, Group/Kind: servicebus.azure.com/Namespace" cannot be found. Progress is blocked until the owner is created.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
