### PR TITLE
FACT-1980 - CVE and Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: daily

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,8 @@ def versions = [
   apiguardian     : '1.1.2',
   flyway          : "$flywayVersion",
   postgresql      : "$postgresqlVersion",
-  shedlock        : '5.15.1'
+  shedlock        : '5.15.1',
+  restAssured     : '5.5.0'
 ]
 
 ext.libraries = [
@@ -265,16 +266,16 @@ dependencies {
   smokeTestImplementation libraries.junit5
   smokeTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
   smokeTestImplementation group: 'com.typesafe', name: 'config', version: '1.4.3'
-  smokeTestImplementation(group: 'io.rest-assured', name: 'rest-assured', version: '5.3.2') {
+  smokeTestImplementation(group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured) {
     exclude group: 'org.apache.groovy', module: 'groovy-xml'
     exclude group: 'org.apache.groovy', module: 'groovy-json'
     exclude group: 'org.codehaus.groovy', module: 'groovy-xml'
     exclude group: 'org.codehaus.groovy', module: 'groovy-json'
   }
-  smokeTestImplementation(group: 'io.rest-assured', name: 'json-path', version: '5.3.2') {
+  smokeTestImplementation(group: 'io.rest-assured', name: 'json-path', version: versions.restAssured) {
     exclude group: 'org.apache.groovy', module: 'groovy-json'
   }
-  smokeTestImplementation(group: 'io.rest-assured', name: 'rest-assured-all', version: '4.5.1') {
+  smokeTestImplementation(group: 'io.rest-assured', name: 'rest-assured-all', version: versions.restAssured) {
     exclude group: 'org.codehaus.groovy', module: 'groovy'
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,7 @@ dependencies {
 
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.4'
 
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.7'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.3'
   implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'
 
   // region: feign clients
@@ -248,7 +248,7 @@ dependencies {
   }
   testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
   testImplementation group: 'io.github.netmikey.logunit', name: 'logunit-core', version: '2.0.0'
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.3', classifier: 'all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.4', classifier: 'all'
   testRuntimeOnly group: 'io.github.netmikey.logunit', name: 'logunit-logback', version: '2.0.0'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,8 @@ def versions = [
   reformLogging   : '6.1.4',
   apiguardian     : '1.1.2',
   flyway          : "$flywayVersion",
-  postgresql      : "$postgresqlVersion"
+  postgresql      : "$postgresqlVersion",
+  shedlock        : '5.15.1'
 ]
 
 ext.libraries = [
@@ -202,8 +203,8 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: versions.postgresql
   implementation group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
 
-  implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.10.2'
-  implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '5.10.2'
+  implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: versions.shedlock
+  implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: versions.shedlock
 
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,7 @@ dependencies {
 
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.4'
 
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.3'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.4'
   implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'
 
   // region: feign clients

--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ dependencies {
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.1'
 
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.7'
-  implementation group: 'com.google.guava', name: 'guava', version: '33.2.1-jre'
+  implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'
 
   // region: feign clients
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -280,7 +280,7 @@ dependencies {
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.smokeTest.runtimeClasspath
-  functionalTestImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.1'
+  functionalTestImplementation group: 'org.awaitility', name: 'awaitility', version: '4.2.2'
 }
 
 mainClassName = 'uk.gov.hmcts.reform.notificationservice.Application'

--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ dependencies {
   smokeTestImplementation sourceSets.main.runtimeClasspath
   smokeTestImplementation sourceSets.test.runtimeClasspath
   smokeTestImplementation libraries.junit5
-  smokeTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+  smokeTestImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
   smokeTestImplementation group: 'com.typesafe', name: 'config', version: '1.4.3'
   smokeTestImplementation(group: 'io.rest-assured', name: 'rest-assured', version: '5.3.2') {
     exclude group: 'org.apache.groovy', module: 'groovy-xml'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.6'
-  id 'org.springframework.boot' version '3.2.7'
+  id 'org.springframework.boot' version '3.3.3'
   id 'org.owasp.dependencycheck' version '9.0.10'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'
@@ -226,7 +226,7 @@ dependencies {
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.0'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.1.2'
 
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.1'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.4'
 
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.7'
   implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'

--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,7 @@ dependencies {
 
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '4.1.4'
 
-  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.4'
+  implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.3'
   implementation group: 'com.google.guava', name: 'guava', version: '33.3.0-jre'
 
   // region: feign clients

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 buildscript {
+  ext {
+    flywayVersion = '10.17.3'
+    postgresqlVersion = '42.7.4'
+  }
   dependencies {
-    classpath("org.postgresql:postgresql:42.7.3")
-    classpath("org.flywaydb:flyway-database-postgresql:10.13.0")
+    classpath("org.postgresql:postgresql:$postgresqlVersion") // must be compatible with flyway version
+    classpath("org.flywaydb:flyway-database-postgresql:$flywayVersion") // flyway dependency/plugin versions must always match
   }
 }
 plugins {
@@ -14,7 +18,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '9.0.10'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '4.4.1.3373'
-  id 'org.flywaydb.flyway' version '10.13.0'
+  id 'org.flywaydb.flyway' version "$flywayVersion"
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -176,7 +180,9 @@ def versions = [
   junit           : '5.10.3',
   junitPlatform   : '1.10.3',
   reformLogging   : '6.1.4',
-  apiguardian     : '1.1.2'
+  apiguardian     : '1.1.2',
+  flyway          : "$flywayVersion",
+  postgresql      : "$postgresqlVersion"
 ]
 
 ext.libraries = [
@@ -191,10 +197,10 @@ ext.libraries = [
 ]
 
 dependencies {
-  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '10.13.0'
+  runtimeOnly group: 'org.flywaydb', name: 'flyway-database-postgresql', version: versions.flyway
 
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
-  implementation group: 'org.flywaydb', name: 'flyway-core', version: '10.13.0'
+  implementation group: 'org.postgresql', name: 'postgresql', version: versions.postgresql
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: versions.flyway
 
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '5.10.2'
   implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '5.10.2'

--- a/charts/reform-scan-notification-service/Chart.yaml
+++ b/charts/reform-scan-notification-service/Chart.yaml
@@ -8,9 +8,9 @@ maintainers:
     email: bspteam@hmcts.net
 dependencies:
   - name: java
-    version: 5.2.0
+    version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: servicebus
-    version: 1.0.6
+    version: 1.0.7
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     condition: servicebus.enabled

--- a/charts/reform-scan-notification-service/Chart.yaml
+++ b/charts/reform-scan-notification-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Reform Scan Notification Service
 name: reform-scan-notification-service
 home: https://github.com/hmcts/reform-scan-notification-service
-version: 2.0.16
+version: 2.0.17
 maintainers:
   - name: HMCTS BSP Team
     email: bspteam@hmcts.net

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,3 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+      <notes>
+        Latest current stable version of Azure Messaging Servicebus (7.17.3) is still bringing
+        in vulnerable Azure libraries.
+      </notes>
+      <cve>CVE-2023-36052</cve>
+    </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,11 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress>
-        <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
-        <cve>CVE-2023-35116</cve>
-    </suppress>
-    <suppress>
-      <notes>Azure cli. Wait for fix.</notes>
-      <cve>CVE-2023-36052</cve>
-    </suppress>
 </suppressions>

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.106.0"
+      version = "3.116.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.47.0"
+      version = "2.53.1"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FACT-1980

### Change description ###

- Flyway/Postgresql version put into buildscript property to ease updating 
- Removed jackson-databind suppression but latest Azzure Messaging Servicebus is still bringing in vulnerable Azure libraries
- Removes dependabot.yml

**Major Version Jump**
- Rest Assured V5

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
