### PR TITLE
FACT-1963 Adds db migration script for testing

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/notificationservice/data/NotificationRepositoryTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.notificationservice.data;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -512,6 +513,7 @@ public class NotificationRepositoryTest {
     }
 
     @Test
+    @Disabled
     void should_throw_exception_for_duplicate_message_id() {
         // given
         String messageId = UUID.randomUUID().toString();

--- a/src/main/resources/db/migration/V012__remove_message_id_constraint.sql
+++ b/src/main/resources/db/migration/V012__remove_message_id_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notifications
+  DROP CONSTRAINT notifications_message_id;


### PR DESCRIPTION
### Change description ###

Add DB migration script for testing. As the dm script drops the need for unique message IDs, the test for that has been disabled.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
